### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The cache directory defaults to the system cache dir but can be configured if yo
 
 ```ruby
 BicFinder.configure do |config|
-  config.check_dir = 'your-prefered-directory'
+  config.cache_dir = 'your-prefered-directory'
 end
 ```
 


### PR DESCRIPTION
In this README.md example:

```ruby
BicFinder.configure do |config|
  config.check_dir = 'your-prefered-directory'
end
```

`check_dir` is probably a typo — it should be `cache_dir`.
